### PR TITLE
update requirements to be more up to data and flexible.

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
 pylama~=7.7.1
 pytest~=5.4.1
-wheel~=0.34.2
-pre-commit~=2.8
+wheel~=0.36.2
+pre-commit~=2.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-add-trailing-comma~=2.0.1
-autoflake~=1.3.1
+add-trailing-comma>=2.0.1
+autoflake>=1.3.1
 ConfigArgParse>=1.0.0,<2
-fixit~=0.1.3
-isort~=5.4.2
-prettylog~=0.3.0
-pyupgrade~=2.1.0
-unify~=0.5
+fixit>=0.1.3,<1
+isort>=5.4.2
+prettylog>=0.3.0
+pyupgrade>=2.1.0
+unify>=0.5


### PR DESCRIPTION
We are using newer versions of the tools called by gray and they work fine at runtime but pip is complaining about the strictness of the versions:
```
ERROR: pip's legacy dependency resolver does not consider dependency conflicts when selecting packages. This behaviour is the source of the following dependency conflicts.
gray 0.8.1 requires isort~=5.4.2, but you'll have isort 5.8.0 which is incompatible.
gray 0.8.1 requires pyupgrade~=2.1.0, but you'll have pyupgrade 2.13.0 which is incompatible.
```
WE have to use the legacy resolver to avoid installation errors.