### PR TITLE
Add support for Black in Gray.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,4 +6,5 @@
 
 ## Contributors
 
-None yet. Why not be the first?
+* Stephane Odul 
+

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Gray stands on the shoulders of giants:
 - [trim](https://github.com/myint/trim) - remove trailing whitespaces
 - [unify](https://github.com/myint/unify) - unify quotes style
 - [fixit](https://github.com/Instagram/Fixit) - various code formatters on LibCST
-
+- [black](https://github.com/psf/black) - optional - the uncompromising Python code formatter
 
 ## Usage
 
@@ -42,8 +42,8 @@ Logging options:
 
 Formatters options:
   -f FORMATTERS, --formatters FORMATTERS
-                        Enabled formatters separated by comma (default: add-
-                        trailing-comma,autoflake,fixit,isort,pyupgrade,trim,unify)
+                        Enabled formatters separated by comma (optional: black)
+                        (default: add-trailing-comma,autoflake,fixit,isort,pyupgrade,trim,unify)
   --min-python-version MIN_PYTHON_VERSION
                         Minimum python version to support (default: (3, 9))
 
@@ -88,6 +88,14 @@ fixit options:
   --fixit-to-comprehensions FIXIT_TO_COMPREHENSIONS
   --fixit-to-literals FIXIT_TO_LITERALS
   --fixit-to-fstrings FIXIT_TO_FSTRINGS
+
+black options:
+  --black-line-length BLACK_LINE_LENGTH
+                        How many characters per line to allow. (default: 88)
+  --black-skip-magic-trailing-comma BLACK_SKIP_MAGIC_TRAILING_COMMA
+                        Don't use trailing commas as a reason to split lines. (default: False)
+  --black-skip-string-normalization BLACK_SKIP_STRING_NORMALIZATION
+                        Don't normalize string quotes or prefixes. (default: False)
 
 Args that start with '--' (eg. --pool-size) can also be set in a config file
 (/Users/apple/.gray or /etc/gray.conf or ./gray.conf). Config file syntax

--- a/gray/formatters/__init__.py
+++ b/gray/formatters/__init__.py
@@ -3,6 +3,7 @@ from types import MappingProxyType
 from .add_trailing_comma import AddTrailingCommaFormatter
 from .autoflake import AutoflakeFormatter
 from .base import BaseFormatter
+from .black import BlackFormatter
 from .composite import CompositeFormatter
 from .fixit import FixitFormatter
 from .isort import SortImportsFormatter
@@ -14,12 +15,15 @@ from .unify import UnifyFormatter
 FORMATTERS = MappingProxyType({
     "add-trailing-comma": AddTrailingCommaFormatter,
     "autoflake": AutoflakeFormatter,
+    "black": BlackFormatter,
     "fixit": FixitFormatter,
     "isort": SortImportsFormatter,
     "pyupgrade": PyUpgradeFormatter,
     "trim": TrimFormatter,
     "unify": UnifyFormatter,
 })
+
+OPTIONAL_FORMATTERS = ('black',)
 
 
 __all__ = ("FORMATTERS", "BaseFormatter", "CompositeFormatter")

--- a/gray/formatters/black.py
+++ b/gray/formatters/black.py
@@ -1,0 +1,35 @@
+"""Black formatter for Gray."""
+
+from argparse import Namespace
+from pathlib import Path
+
+import black
+from configargparse import Namespace
+
+from gray.formatters.base import BaseFormatter
+
+
+class BlackFormatter(BaseFormatter):
+    """Black formatter class."""
+
+    def __init__(self, arguments: Namespace):
+        self._args = Namespace(
+            line_length=arguments.black_line_length,
+            skip_magic_trailing_comma=arguments.black_skip_magic_trailing_comma,
+            skip_string_normalization=arguments.black_skip_string_normalization,
+        )
+        self._mode = black.Mode(
+            line_length=self._args.line_length,
+            magic_trailing_comma=not self._args.skip_magic_trailing_comma,
+            string_normalization=not self._args.skip_string_normalization,
+        )
+
+    def process(self, file_path: Path):
+        # Black does not provide an official public API yet:
+        # https://github.com/psf/black/issues/779
+        black.reformat_one(
+            file_path,
+            fast=False,
+            write_back=black.WriteBack.YES,
+            mode=self._mode,
+            report=black.Report())

--- a/gray/formatters/composite.py
+++ b/gray/formatters/composite.py
@@ -6,10 +6,10 @@ from gray.formatters.base import BaseFormatter
 class CompositeFormatter(BaseFormatter):
     # Use a list to guarantee order preserving, which can be important to
     # ensure that the formatters are going to behave consistently.
-    _formatters: list
+    _formatters: tuple
 
     def __init__(self, *formatters):
-        self._formatters = list(formatters)
+        self._formatters = tuple(formatters)
 
     def process(self, file_path: Path):
         for formatter in self._formatters:

--- a/gray/formatters/composite.py
+++ b/gray/formatters/composite.py
@@ -4,10 +4,12 @@ from gray.formatters.base import BaseFormatter
 
 
 class CompositeFormatter(BaseFormatter):
-    _formatters: frozenset
+    # Use a list to guarantee order preserving, which can be important to
+    # ensure that the formatters are going to behave consistently.
+    _formatters: list
 
     def __init__(self, *formatters):
-        self._formatters = frozenset(formatters)
+        self._formatters = list(formatters)
 
     def process(self, file_path: Path):
         for formatter in self._formatters:

--- a/gray/main.py
+++ b/gray/main.py
@@ -7,12 +7,15 @@ from pathlib import Path
 import configargparse
 from prettylog import LogFormat, basic_config
 
-from gray.formatters import FORMATTERS
+from gray.formatters import FORMATTERS, OPTIONAL_FORMATTERS
 from gray.processing import FormattingError, process
 from gray.utils.args import parse_bool, parse_formatters
 
 
-FORMATTERS_NAMES = ",".join(FORMATTERS.keys())
+FORMATTERS_NAMES = ",".join(
+    x for x in sorted(FORMATTERS.keys()) if x not in OPTIONAL_FORMATTERS
+)
+OPTIONAL_FORMATTERS_NAMES = ",".join(OPTIONAL_FORMATTERS)
 
 log = logging.getLogger(__name__)
 
@@ -67,7 +70,7 @@ group = parser.add_argument_group("Formatters options")
 group.add_argument(
     "-f",
     "--formatters",
-    help="Enabled formatters separated by comma",
+    help=f"Enabled formatters separated by comma (optional: {OPTIONAL_FORMATTERS_NAMES})",
     type=parse_formatters,
     default=FORMATTERS_NAMES,
 )
@@ -195,6 +198,26 @@ group.add_argument(
     "--fixit-to-fstrings",
     type=parse_bool,
     default=True,
+)
+
+group = parser.add_argument_group("black options")
+group.add_argument(
+    "--black-line-length",
+    help="How many characters per line to allow.",
+    type=int,
+    default=88,
+)
+group.add_argument(
+    "--black-skip-magic-trailing-comma",
+    help="Don't use trailing commas as a reason to split lines.",
+    type=parse_bool,
+    default=False,
+)
+group.add_argument(
+    "--black-skip-string-normalization",
+    help="Don't normalize string quotes or prefixes.",
+    type=parse_bool,
+    default=False,
 )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 add-trailing-comma>=2.1.0
 autoflake>=1.3.1
+black>=21.6b0
 ConfigArgParse>=1.0.0,<2
 fixit>=0.1.3,<1
 isort>=5.4.2

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,0 +1,50 @@
+"""Unittests for gray.formatters.composite."""
+
+import pathlib
+import unittest
+from unittest import mock
+from gray.formatters.composite import CompositeFormatter
+from gray.formatters.base import BaseFormatter
+
+class FakeFormatter(BaseFormatter):
+    """Fake Formatter Class for testing."""
+
+    def __init__(self, name, callback):
+        self.name = name
+        self.callback = callback
+
+    def process(self, file_path: pathlib.Path):
+        self.callback(self.name, file_path)
+
+
+class TestCompositeFormatter(unittest.TestCase):
+    """Test the CompositeFormatter class."""
+
+    def test_composite_preserves_order(self):
+        callback = mock.MagicMock()
+        formatter_a = FakeFormatter('a', callback)
+        formatter_b = FakeFormatter('b', callback)
+        formatter_c = FakeFormatter('c', callback)
+        self.assertIsNot(formatter_a, formatter_b)
+        self.assertIsNot(formatter_b, formatter_c)
+
+        fake_path = pathlib.Path('/fake/file.py')
+
+        formatters = CompositeFormatter(formatter_a, formatter_b, formatter_c)
+        formatters.process(fake_path)
+        self.assertEqual(3, callback.call_count)
+        callback.assert_has_calls([
+            mock.call('a', fake_path),
+            mock.call('b', fake_path),
+            mock.call('c', fake_path),
+        ])
+
+        callback.reset_mock()
+        formatters = CompositeFormatter(formatter_c, formatter_b, formatter_a)
+        formatters.process(fake_path)
+        self.assertEqual(3, callback.call_count)
+        callback.assert_has_calls([
+            mock.call('c', fake_path),
+            mock.call('b', fake_path),
+            mock.call('a', fake_path),
+        ])


### PR DESCRIPTION
Fixes #8 

I added a change to preserve the order of the formatters. The existing implementation was dependent on how frozen set are implemented which mean that they could run in different order from one version of python to the other.

This will run the default formatters in the same order as the list is defined in code, or respect the order from the `--formatters` option.

In our case it is important that we run `pyugrade` before `black`, but `isort` after `black`. This guarantees that the final file stays consistent.

I added a unittest to ensure that the order is preserved.