### PR TITLE
Add isort options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# IntelliJ/PyCharm
+.idea/
+
+
 *.py[cod]
 
 # C extensions

--- a/README.md
+++ b/README.md
@@ -60,16 +60,46 @@ unify options:
                         preferred quote (default: ")
 
 isort options:
+  --isort-profile ISORT_PROFILE
+                        Base profile type to use for configuration. (default: None)
   --isort-line-length ISORT_LINE_LENGTH
-                        isort section (default: 80)
+                        The max length of an import line (used for wrapping long imports)
+                        (default: 80)
+  --isort-wrap-length ISORT_WRAP_LENGTH
+                        Specifies how long lines that are wrapped should be, if not set
+                        line_length is used. NOTE: wrap_length must be LOWER than or equal to
+                        line_length (default: None)
+  --isort-multi-line-output ISORT_MULTI_LINE_OUTPUT
+                        Multi line output (0-grid, 1-vertical, 2-hanging, 3-vert-hanging, 4-vert-
+                        grid, 5-vert-grid-grouped, 6-deprecated-alias-for-5, 7-noqa, 8-vertical-
+                        hanging-indent-bracket, 9-vertical-prefix-from-module-import, 10-hanging-
+                        indent-with-parentheses). (default: 5)
+  --isort-known-third-party ISORT_KNOWN_THIRD_PARTY
+                        Force isort to recognize a module as being part of a third party library.
+                        (default: None)
+  --isort-known-first-party ISORT_KNOWN_FIRST_PARTY
+                        Force isort to recognize a module as being part of the current python
+                        project. (default: None)
+  --isort-known-local-folder ISORT_KNOWN_LOCAL_FOLDER
+                        Force isort to recognize a module as being a local folder. Generally, this
+                        is reserved for relative imports (from . import module). (default: None)
   --isort-virtual-env ISORT_VIRTUAL_ENV
-                        virtual env path (default:
-                        /Users/dizballanze/apps/gray/env)
+                        virtual env path (default: env)
   --isort-include-trailing-comma ISORT_INCLUDE_TRAILING_COMMA
-                        include a trailing comma on multi line imports
-                        (default: 1)
+                        Includes a trailing comma on multi line imports that include parentheses.
+                        (default: True)
   --isort-lines-after-imports ISORT_LINES_AFTER_IMPORTS
                         empty lines after imports (default: 2)
+  --isort-skip-gitignore ISORT_SKIP_GITIGNORE
+                        Treat project as a git repository and ignore files listed in .gitignore.
+                        (default: True)
+  --isort-use-parentheses ISORT_USE_PARENTHESES
+                        Use parentheses for line continuation on length limit instead of slashes.
+                        **NOTE**: This is separate from wrap modes, and only affects how
+                        individual lines that are too long get continued, not sections of multiple
+                        imports.. (default: True)
+  --isort-length-sort ISORT_LENGTH_SORT
+                        Sort imports by their string length. (default: False)
 
 autoflake options:
   --autoflake-ignore-init-module-imports AUTOFLAKE_IGNORE_INIT_MODULE_IMPORTS

--- a/gray/formatters/isort.py
+++ b/gray/formatters/isort.py
@@ -1,3 +1,5 @@
+"""Handle the isort formatter."""
+
 from pathlib import Path
 
 from configargparse import Namespace
@@ -7,6 +9,7 @@ from gray.formatters.base import BaseFormatter
 
 
 class SortImportsFormatter(BaseFormatter):
+    """Sort imports through isort."""
 
     def __init__(self, arguments: Namespace):
         self._settings = {
@@ -17,16 +20,34 @@ class SortImportsFormatter(BaseFormatter):
             ],
             "line_length": arguments.isort_line_length,
             "indent": "    ",
-            "multi_line_output": 5,
-            "length_sort": 0,
+            "multi_line_output": arguments.isort_multi_line_output,
+            "length_sort": arguments.isort_length_sort,
             "default_section": "THIRDPARTY",
             "virtual_env": str(arguments.isort_virtual_env),
             "include_trailing_comma": arguments.isort_include_trailing_comma,
             "lines_after_imports": arguments.isort_lines_after_imports,
-            "use_parentheses": True,
+            "use_parentheses": arguments.isort_use_parentheses,
         }
+        # We do not override further isort defaults here.
+        if arguments.isort_profile:
+            self._settings["profile"] = arguments.isort_profile
+        if arguments.isort_wrap_length:
+            self._settings["wrap_length"] = arguments.isort_wrap_length
+        if arguments.isort_known_third_party:
+            self._settings["known_third_party"] = (
+                arguments.isort_known_third_party)
+        if arguments.isort_known_first_party:
+            self._settings["known_first_party"] = (
+                arguments.isort_known_first_party)
+        if arguments.isort_known_local_folder:
+            self._settings["known_local_folder"] = (
+                arguments.isort_known_local_folder)
+        if arguments.isort_skip_gitignore:
+            self._settings["skip_gitignore"] = arguments.isort_skip_gitignore
+
 
     def process(self, file_path: Path):
+        """Process the given file through isort."""
         sort_file(
             filename=str(file_path),
             **self._settings,

--- a/gray/main.py
+++ b/gray/main.py
@@ -9,7 +9,7 @@ from prettylog import LogFormat, basic_config
 
 from gray.formatters import FORMATTERS, OPTIONAL_FORMATTERS
 from gray.processing import FormattingError, process
-from gray.utils.args import parse_bool, parse_formatters
+from gray.utils.args import parse_bool, parse_formatters, parse_frozenset
 
 
 FORMATTERS_NAMES = ",".join(
@@ -19,209 +19,278 @@ OPTIONAL_FORMATTERS_NAMES = ",".join(OPTIONAL_FORMATTERS)
 
 log = logging.getLogger(__name__)
 
+def get_parser():
+    parser = configargparse.ArgumentParser(
+        add_env_var_help=False,
+        allow_abbrev=False,
+        auto_env_var_prefix="GRAY_",
+        description="Less uncompromising Python code formatter.",
+        default_config_files=[
+            os.path.join(os.path.expanduser("~"), ".gray"),
+            "/etc/gray.conf",
+            "./gray.conf",
+        ],
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        ignore_unknown_config_file_keys=True,
+        usage="""
+            gray myapp.py
+            gray myproj/ tests/
+            gray --log-level debug --formatters isort,unify ~/app
+        """,
+    )
 
-parser = configargparse.ArgumentParser(
-    add_env_var_help=False,
-    allow_abbrev=False,
-    auto_env_var_prefix="GRAY_",
-    description="Less uncompromising Python code formatter.",
-    default_config_files=[
-        os.path.join(os.path.expanduser("~"), ".gray"),
-        "/etc/gray.conf",
-        "./gray.conf",
-    ],
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    ignore_unknown_config_file_keys=True,
-    usage="""
-        gray myapp.py
-        gray myproj/ tests/
-        gray --log-level debug --formatters isort,unify ~/app
-    """,
-)
+    parser.add_argument(
+        "paths", nargs="*", help="Paths to format", type=Path,
+        default=(Path("."),),
+    )
 
-parser.add_argument(
-    "paths", nargs="*", help="Paths to format", type=Path, default=(Path("."),),
-)
+    parser.add_argument(
+        "--pool-size",
+        help="process pool size",
+        type=int,
+        default=8,
+    )
 
-parser.add_argument(
-    "--pool-size",
-    help="process pool size",
-    type=int,
-    default=8,
-)
+    parser.add_argument(
+        "--do-not-detect-venv",
+        help="Don't try to detect virtualenv",
+        action="store_true",
+    )
 
-parser.add_argument(
-    "--do-not-detect-venv",
-    help="Don't try to detect virtualenv",
-    action="store_true",
-)
+    group = parser.add_argument_group("Logging options")
+    group.add_argument(
+        "--log-level",
+        default="info",
+        choices=("debug", "info", "warning", "error", "fatal"),
+    )
+    group.add_argument(
+        "--log-format", choices=LogFormat.choices(), default="color",
+    )
 
-group = parser.add_argument_group("Logging options")
-group.add_argument(
-    "--log-level",
-    default="info",
-    choices=("debug", "info", "warning", "error", "fatal"),
-)
-group.add_argument(
-    "--log-format", choices=LogFormat.choices(), default="color",
-)
+    group = parser.add_argument_group("Formatters options")
+    group.add_argument(
+        "-f",
+        "--formatters",
+        help=f"Enabled formatters separated by comma"
+            " (optional: {OPTIONAL_FORMATTERS_NAMES})",
+        type=parse_formatters,
+        default=FORMATTERS_NAMES,
+    )
+    group.add_argument(
+        "--min-python-version",
+        help="Minimum python version to support",
+        default=(sys.version_info.major, sys.version_info.minor),
+        type=lambda x: tuple(int(d) for d in x.split(".")),
+    )
 
-group = parser.add_argument_group("Formatters options")
-group.add_argument(
-    "-f",
-    "--formatters",
-    help=f"Enabled formatters separated by comma (optional: {OPTIONAL_FORMATTERS_NAMES})",
-    type=parse_formatters,
-    default=FORMATTERS_NAMES,
-)
-group.add_argument(
-    "--min-python-version",
-    help="Minimum python version to support",
-    default=(sys.version_info.major, sys.version_info.minor),
-    type=lambda x: tuple(int(d) for d in x.split(".")),
-)
+    group = parser.add_argument_group("pyupgrade options")
+    group.add_argument(
+        "--pyupgrade-keep-percent-format",
+        help="Do not upgrade percent formatted strings to f-strings",
+        type=parse_bool,
+        default=False,
+    )
+    group.add_argument(
+        "--pyupgrade-keep-mock",
+        help="Disable rewrite of mock imports",
+        type=parse_bool,
+        default=False,
+    )
+    group.add_argument(
+        "--pyupgrade-keep-runtime-typing",
+        help="Disable pep 585 typing rewrites",
+        type=parse_bool,
+        default=False,
+    )
 
-group = parser.add_argument_group("pyupgrade options")
-group.add_argument(
-    "--pyupgrade-keep-percent-format",
-    help="Do not upgrade percent formatted strings to f-strings",
-    type=parse_bool,
-    default=False,
-)
-group.add_argument(
-    "--pyupgrade-keep-mock",
-    help="Disable rewrite of mock imports",
-    type=parse_bool,
-    default=False,
-)
-group.add_argument(
-    "--pyupgrade-keep-runtime-typing",
-    help="Disable pep 585 typing rewrites",
-    type=parse_bool,
-    default=False,
-)
+    group = parser.add_argument_group("unify options")
+    group.add_argument(
+        "--unify-quote",
+        help="preferred quote",
+        default='"',
+    )
 
-group = parser.add_argument_group("unify options")
-group.add_argument(
-    "--unify-quote",
-    help="preferred quote",
-    default='"',
-)
+    group = parser.add_argument_group("isort options")
+    group.add_argument(
+        "--isort-profile",
+        help="Base profile type to use for configuration.",
+        type=str,
+    )
+    group.add_argument(
+        "--isort-line-length",
+        help="The max length of an import line"
+            " (used for wrapping long imports)",
+        type=int,
+        default=80,
+    )
+    group.add_argument(
+        "--isort-wrap-length",
+        help="Specifies how long lines that are wrapped should be, if not set"
+            " line_length is used. NOTE: wrap_length must be LOWER than or"
+            " equal to line_length",
+        type=int,
+    )
+    group.add_argument(
+        "--isort-multi-line-output",
+        help="Multi line output (0-grid, 1-vertical, 2-hanging, 3-vert-hanging,"
+            " 4-vert-grid, 5-vert-grid-grouped, 6-deprecated-alias-for-5,"
+            " 7-noqa, 8-vertical-hanging-indent-bracket,"
+            " 9-vertical-prefix-from-module-import,"
+            " 10-hanging-indent-with-parentheses).",
+        type=int,
+        default=5,
+    )
+    group.add_argument(
+        "--isort-known-third-party",
+        help="Force isort to recognize a module as being part of a third party"
+            " library.",
+        type=parse_frozenset,
+    )
+    group.add_argument(
+        "--isort-known-first-party",
+        help="Force isort to recognize a module as being part of the current"
+             " python project.",
+        type=parse_frozenset,
+    )
+    group.add_argument(
+        "--isort-known-local-folder",
+        help="Force isort to recognize a module as being a local folder."
+            " Generally, this is reserved for relative imports"
+            " (from . import module).",
+        type=parse_frozenset,
+    )
+    group.add_argument(
+        "--isort-virtual-env",
+        help="virtual env path",
+        type=Path,
+        default=os.environ.get("VIRTUAL_ENV", "env"),
+    )
+    group.add_argument(
+        "--isort-include-trailing-comma",
+        help="Includes a trailing comma on multi line imports that include"
+            " parentheses.",
+        type=bool,
+        default=True,
+    )
+    group.add_argument(
+        "--isort-lines-after-imports",
+        help="empty lines after imports",
+        type=int,
+        default=2,
+    )
+    group.add_argument(
+        "--isort-skip-gitignore",
+        help="Treat project as a git repository and ignore files listed in"
+            " .gitignore.",
+        type=bool,
+        default=True,
+    )
+    group.add_argument(
+        "--isort-use-parentheses",
+        help="Use parentheses for line continuation on length limit instead of"
+            " slashes. **NOTE**: This is separate from wrap modes, and only"
+            " affects how individual lines that are too long get continued, not"
+            " sections of multiple imports..",
+        type=bool,
+        default=True,
+    )
+    group.add_argument(
+        "--isort-length-sort",
+        help="Sort imports by their string length.",
+        type=bool,
+        default=False,
+    )
 
-group = parser.add_argument_group("isort options")
-group.add_argument(
-    "--isort-line-length",
-    help="isort section",
-    type=int,
-    default=80,
-)
-group.add_argument(
-    "--isort-virtual-env",
-    help="virtual env path",
-    type=Path,
-    default=os.environ.get("VIRTUAL_ENV", "env"),
-)
-group.add_argument(
-    "--isort-include-trailing-comma",
-    help="include a trailing comma on multi line imports",
-    type=int,
-    default=1,
-)
-group.add_argument(
-    "--isort-lines-after-imports",
-    help="empty lines after imports",
-    type=int,
-    default=2,
-)
+    group = parser.add_argument_group("autoflake options")
+    group.add_argument(
+        "--autoflake-ignore-init-module-imports",
+        type=parse_bool,
+        default=True,
+    )
+    group.add_argument(
+        "--autoflake-expand-star-imports",
+        type=parse_bool,
+        default=False,
+    )
+    group.add_argument(
+        "--autoflake-remove-all-unused-imports",
+        type=parse_bool,
+        default=True,
+    )
+    group.add_argument(
+        "--autoflake-remove-duplicate-keys",
+        type=parse_bool,
+        default=True,
+    )
+    group.add_argument(
+        "--autoflake-remove-unused-variables",
+        type=parse_bool,
+        default=True,
+    )
 
-group = parser.add_argument_group("autoflake options")
-group.add_argument(
-    "--autoflake-ignore-init-module-imports",
-    type=parse_bool,
-    default=True,
-)
-group.add_argument(
-    "--autoflake-expand-star-imports",
-    type=parse_bool,
-    default=False,
-)
-group.add_argument(
-    "--autoflake-remove-all-unused-imports",
-    type=parse_bool,
-    default=True,
-)
-group.add_argument(
-    "--autoflake-remove-duplicate-keys",
-    type=parse_bool,
-    default=True,
-)
-group.add_argument(
-    "--autoflake-remove-unused-variables",
-    type=parse_bool,
-    default=True,
-)
+    group = parser.add_argument_group("trim options")
+    group.add_argument(
+        "--trim-leading-newlines",
+        type=parse_bool,
+        default=True,
+    )
 
-group = parser.add_argument_group("trim options")
-group.add_argument(
-    "--trim-leading-newlines",
-    type=parse_bool,
-    default=True,
-)
+    group = parser.add_argument_group("fixit options")
+    group.add_argument(
+        "--fixit-redundant-fstrings",
+        type=parse_bool,
+        default=True,
+    )
+    group.add_argument(
+        "--fixit-redundant-lambdas",
+        type=parse_bool,
+        default=True,
+    )
+    group.add_argument(
+        "--fixit-redundant-list-comprehensions",
+        type=parse_bool,
+        default=True,
+    )
+    group.add_argument(
+        "--fixit-to-comprehensions",
+        type=parse_bool,
+        default=True,
+    )
+    group.add_argument(
+        "--fixit-to-literals",
+        type=parse_bool,
+        default=True,
+    )
+    group.add_argument(
+        "--fixit-to-fstrings",
+        type=parse_bool,
+        default=True,
+    )
 
-group = parser.add_argument_group("fixit options")
-group.add_argument(
-    "--fixit-redundant-fstrings",
-    type=parse_bool,
-    default=True,
-)
-group.add_argument(
-    "--fixit-redundant-lambdas",
-    type=parse_bool,
-    default=True,
-)
-group.add_argument(
-    "--fixit-redundant-list-comprehensions",
-    type=parse_bool,
-    default=True,
-)
-group.add_argument(
-    "--fixit-to-comprehensions",
-    type=parse_bool,
-    default=True,
-)
-group.add_argument(
-    "--fixit-to-literals",
-    type=parse_bool,
-    default=True,
-)
-group.add_argument(
-    "--fixit-to-fstrings",
-    type=parse_bool,
-    default=True,
-)
-
-group = parser.add_argument_group("black options")
-group.add_argument(
-    "--black-line-length",
-    help="How many characters per line to allow.",
-    type=int,
-    default=88,
-)
-group.add_argument(
-    "--black-skip-magic-trailing-comma",
-    help="Don't use trailing commas as a reason to split lines.",
-    type=parse_bool,
-    default=False,
-)
-group.add_argument(
-    "--black-skip-string-normalization",
-    help="Don't normalize string quotes or prefixes.",
-    type=parse_bool,
-    default=False,
-)
+    group = parser.add_argument_group("black options")
+    group.add_argument(
+        "--black-line-length",
+        help="How many characters per line to allow.",
+        type=int,
+        default=88,
+    )
+    group.add_argument(
+        "--black-skip-magic-trailing-comma",
+        help="Don't use trailing commas as a reason to split lines.",
+        type=parse_bool,
+        default=False,
+    )
+    group.add_argument(
+        "--black-skip-string-normalization",
+        help="Don't normalize string quotes or prefixes.",
+        type=parse_bool,
+        default=False,
+    )
+    return parser
 
 
 def main():
+    parser = get_parser()
     arguments = parser.parse_args()
     basic_config(
         level=arguments.log_level,

--- a/gray/utils/args.py
+++ b/gray/utils/args.py
@@ -3,23 +3,30 @@ from configargparse import ArgumentError
 from gray.formatters import FORMATTERS
 
 
-def parse_formatters(v):
-    formatters = v.split(",")
+def parse_formatters(v: str):
+    """Validate and returns the formatters to use as a list."""
+    formatters = [x.strip() for x in v.split(",") if x.strip()]
 
     for formatter_name in formatters:
         if formatter_name not in FORMATTERS:
-            raise ArgumentError(f"Uknown formatter {formatter_name}")
+            raise ValueError(f"Uknown formatter {formatter_name}")
 
     return formatters
 
 
 def parse_bool(v):
+    """Returns a command line flag as a boolean."""
     if isinstance(v, bool):
-       return v
+        return v
 
     if v.lower() in ("yes", "true", "t", "y", "1"):
         return True
-    elif v.lower() in ("no", "false", "f", "n", "0"):
+    if v.lower() in ("no", "false", "f", "n", "0"):
         return False
 
-    raise ArgumentError("Boolean value expected.")
+    raise ValueError("Boolean value expected.")
+
+
+def parse_frozenset(v: str):
+    """Returns a comma separated string as a frozen set."""
+    return frozenset(x.strip() for x in v.split(",") if x.strip())

--- a/tests/test_utils_args.py
+++ b/tests/test_utils_args.py
@@ -1,0 +1,48 @@
+"""Unittests for gray.utils.args."""
+
+import pathlib
+import unittest
+from unittest import mock
+import gray.formatters as formatters
+import gray.utils.args as utils_args
+
+
+class TestArgs(unittest.TestCase):
+    """Test the args module."""
+
+    def test_parse_formatters_empty(self):
+        self.assertEqual([], utils_args.parse_formatters(""))
+        self.assertEqual([], utils_args.parse_formatters(" ,, "))
+
+    def test_parse_formatters_success(self):
+        expected = ['isort', 'unify']
+        received = utils_args.parse_formatters("isort,unify")
+        self.assertEqual(expected, received)
+        received = utils_args.parse_formatters("isort, unify,")
+        self.assertEqual(expected, received)
+
+    def test_parse_formatters_error(self):
+        with self.assertRaises(ValueError):
+            utils_args.parse_formatters("fake_formatter")
+
+    def test_parse_bool_true(self):
+        cases = (True, "YES", "TRUE", "T", "Y", "1")
+        for case in cases:
+            with self.subTest(case):
+                self.assertIs(True, utils_args.parse_bool(case))
+
+    def test_parse_bool_false(self):
+        cases = (False, "NO", "FALSE", "F", "N", "0")
+        for case in cases:
+            with self.subTest(case):
+                self.assertIs(False, utils_args.parse_bool(case))
+
+    def test_parse_frozenset_empty(self):
+        self.assertEqual(frozenset(), utils_args.parse_frozenset(""))
+        self.assertEqual(frozenset(), utils_args.parse_frozenset(" ,, "))
+
+    def test_parse_frozenset_success(self):
+        self.assertEqual(
+            frozenset({'bar', 'foo'}), utils_args.parse_frozenset("foo,bar"))
+        self.assertEqual(
+            frozenset({'bar', 'foo'}), utils_args.parse_frozenset(" foo,, bar"))


### PR DESCRIPTION
This adds the following isort options:
* --isort-profile
* --isort-wrap-length
* --isort-multi-line-output
* --isort-known-third-party
* --isort-known-first-party
* --isort-known-local-folder
* --isort-skip-gitignore
* --isort-use-parentheses
* --isort-length-sort

The newer options do not override isort own defaults to help ensure profile consistency. The existing gray defaults stay the same.

Added unittests for the args.py module.
Fixed a bug in args.py where raising an `ArgumentError` was failing at runtime, replaced it with a `ValueError`.