### PR TITLE
Add python 3.10 to tox.init, update requirements.

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-pylama~=7.7.1
-pytest~=5.4.1
-wheel~=0.36.2
+pylama~=8.3.7
+pytest~=7.0.1
+wheel~=0.37.1
 pre-commit~=2.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-add-trailing-comma>=2.1.0
-autoflake>=1.3.1
-black>=21.6b0
-ConfigArgParse>=1.0.0,<2
-fixit>=0.1.3,<1
-isort>=5.4.2
+add-trailing-comma>=2.2.1
+autoflake>=1.4
+black>=22.1.0
+ConfigArgParse>=1.5.3,<2
+fixit>=0.1.4,<1
+isort>=5.10.1
 prettylog>=0.3.0
-pyupgrade>=2.15.0
+pyupgrade>=2.31.0
 unify>=0.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py36, py37, py38, py39, py310
 
 [testenv]
 setenv =


### PR DESCRIPTION
This adds Python 3.10 as a test target for tox.

The requirements are updated to the latest versions, including Black which is now out of Beta.

I suggest removing support for Python 3.6, at least for runtime, since it is not longer maintained.