### PR TITLE
README: remove --log-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ optional arguments:
 
 Logging options:
   --log-level {debug,info,warning,error,fatal}
-  --log-format {stream,color,json,syslog}
 
 Formatters options:
   -f FORMATTERS, --formatters FORMATTERS


### PR DESCRIPTION
Hello!

A quick fix to the README file. I tried to use that option and I got confused.

Note that we are planning on using your suite on our various python projects, so you might expect more contributions from us in the upcoming month ;-)

Commitlog:

This option has been removed in commit a3312158c8f0 ("use rich instead of prettylog")

Fixes: a3312158c8f0 ("use rich instead of prettylog")