### PR TITLE
Add support for isort add-imports and remove-imports features.

### DIFF
--- a/gray/formatters/isort.py
+++ b/gray/formatters/isort.py
@@ -47,6 +47,10 @@ class SortImportsFormatter(BaseFormatter):
             )
         if arguments.isort_skip_gitignore:
             self._settings["skip_gitignore"] = arguments.isort_skip_gitignore
+        if arguments.isort_add_imports:
+            self._settings["add_imports"] = arguments.isort_add_imports
+        if arguments.isort_remove_imports:
+            self._settings["remove_imports"] = arguments.isort_remove_imports
 
     def process(self, file_path: Path):
         """Process the given file through isort."""

--- a/gray/main.py
+++ b/gray/main.py
@@ -167,7 +167,7 @@ def get_parser() -> configargparse.ArgumentParser:
     group.add_argument(
         "--isort-known-first-party",
         help="Force isort to recognize a module as being part of the current"
-             " python project.",
+            " python project.",
         type=parse_frozenset,
     )
     group.add_argument(
@@ -217,6 +217,17 @@ def get_parser() -> configargparse.ArgumentParser:
         help="Sort imports by their string length.",
         type=parse_bool,
         default=False,
+    )
+    group.add_argument(
+        "--isort-add-imports",
+        help="Adds the specified import lines to all files,"
+            " automatically determining correct placement.",
+        type=parse_frozenset,
+    )
+    group.add_argument(
+        "--isort-remove-imports",
+        help="Removes the specified imports from all files.",
+        type=parse_frozenset,
     )
 
     group = parser.add_argument_group("autoflake options")


### PR DESCRIPTION
This allows to configure gray.conf with useful common import such as:
```
isort-add-imports = "from __future__ import annotations"
```
